### PR TITLE
Translate code comments to English

### DIFF
--- a/src/Controller/AppController.php
+++ b/src/Controller/AppController.php
@@ -67,12 +67,12 @@ class AppController extends Controller
         $this->loadComponent('Flash');
 		$this->set('authuser', $this->Auth->user());
 
-        # CSRF-Protection aktiviert (Security-Hardening)
-        # Nur CSRF-Token-Validierung, keine SSL-Erzwingung oder Formular-Tampering-Checks
+        // CSRF protection enabled (security hardening)
+        // Only CSRF token validation, no SSL enforcement or form tampering checks
         $this->loadComponent('Security', [
             'blackHoleCallback' => 'blackhole',
-            'requireSecure' => false,  # Keine SSL-Erzwingung (für lokale Entwicklung)
-            'validatePost' => false    # Kein Formular-Tampering-Check (würde bestehende Forms brechen)
+            'requireSecure' => false,  // No SSL enforcement (for local development)
+            'validatePost' => false    // No form tampering check (would break existing forms)
         ]);
 
         // Prior to 3.5 use I18n::locale()
@@ -103,22 +103,25 @@ class AppController extends Controller
    }
 
    /**
-    * Blackhole-Callback für Security-Component
-    * Wird aufgerufen wenn CSRF-Token fehlt/ungültig ist
+    * Blackhole callback for Security component
+    * Called when CSRF token is missing or invalid
+    *
+    * @param string $type The type of security violation
+    * @return \Cake\Http\Response|null
     */
    public function blackhole($type)
    {
-       # Log für Debugging
+       // Log for debugging
        $this->log('Security blackhole: ' . $type, 'error');
 
-       # Benutzerfreundliche Fehlermeldung
+       // User-friendly error message
        if ($type === 'csrf') {
            $this->Flash->error(__('Sicherheitswarnung: Ihre Sitzung ist abgelaufen oder die Anfrage war ungültig. Bitte versuchen Sie es erneut.'));
        } else {
            $this->Flash->error(__('Sicherheitswarnung: Ungültige Anfrage.'));
        }
 
-       # Redirect zur Login-Seite
+       // Redirect to login page
        return $this->redirect(['controller' => 'Users', 'action' => 'login']);
    }
 }

--- a/src/Controller/UsersController.php
+++ b/src/Controller/UsersController.php
@@ -6,13 +6,23 @@ use Cake\Event\Event;
 
 class UsersController extends AppController
 {
-
+    /**
+     * Before filter - allow login/logout without authentication
+     *
+     * @param \Cake\Event\Event $event The event
+     * @return void
+     */
     public function beforeFilter(Event $event)
     {
         parent::beforeFilter($event);
         $this->Auth->allow(['login', 'logout']);
     }
 
+    /**
+     * Index method - list all users
+     *
+     * @return void
+     */
      public function index()
      {
          $query = $this->Users->query();
@@ -68,7 +78,7 @@ class UsersController extends AppController
             $user->username = $this->school['kurzname'] . "-" . $schoolusers->count();
             $user->name = $this->school['name'] . " " . $schoolusers->count();
             $user->roles = ['user' => 'User'];
-            # Standard-Passwort für Schüler aus Umgebungsvariable
+            // Default password for students from environment variable
             $user->password = env('DEFAULT_USER_PASSWORD', 'ChangeMe123');
         	$passworddefault = env('DEFAULT_USER_PASSWORD', 'ChangeMe123');
         }
@@ -125,6 +135,12 @@ class UsersController extends AppController
 
         return $this->redirect(['action' => 'index']);
     }
+
+    /**
+     * Login method - authenticate user
+     *
+     * @return \Cake\Http\Response|null Redirects on successful login
+     */
 	    public function login()
 	    {
 	        if ($this->request->is('post')) {
@@ -137,6 +153,11 @@ class UsersController extends AppController
 	        }
 	    }
 
+    /**
+     * Logout method - end user session
+     *
+     * @return \Cake\Http\Response Redirects to login page
+     */
 	    public function logout()
 	    {
 	        return $this->redirect($this->Auth->logout());

--- a/src/Model/Table/SchoolsTable.php
+++ b/src/Model/Table/SchoolsTable.php
@@ -92,14 +92,14 @@ class SchoolsTable extends Table
     }
 
     /**
-     * Validation rules für Self-Service Registrierung (strengere Regeln)
+     * Validation rules for self-service registration (stricter rules)
      *
      * @param \Cake\Validation\Validator $validator Validator instance.
      * @return \Cake\Validation\Validator
      */
     public function validationRegister(Validator $validator)
     {
-        # Basis-Validation
+        // Base validation
         $validator
             ->integer('id')
             ->allowEmpty('id', 'create');
@@ -110,25 +110,25 @@ class SchoolsTable extends Table
             ->requirePresence('name', 'create')
             ->notEmpty('name', 'Bitte geben Sie einen Schulnamen an.');
 
-        # Kurzname wird automatisch generiert, daher nur allowEmpty
+        // Short name is auto-generated, so just allowEmpty
         $validator
             ->scalar('kurzname')
             ->maxLength('kurzname', 20)
             ->allowEmpty('kurzname');
 
-        # IBAN-Prefix wird automatisch generiert
+        // IBAN prefix is auto-generated
         $validator
             ->scalar('ibanprefix')
             ->maxLength('ibanprefix', 4)
             ->allowEmpty('ibanprefix');
 
-        # BIC wird automatisch generiert
+        // BIC is auto-generated
         $validator
             ->scalar('bic')
             ->maxLength('bic', 255)
             ->allowEmpty('bic');
 
-        # Status wird automatisch gesetzt
+        // Status is set automatically
         $validator
             ->scalar('status')
             ->allowEmpty('status');
@@ -137,11 +137,16 @@ class SchoolsTable extends Table
     }
 
     /**
-     * Sanitize input vor dem Speichern (XSS-Schutz)
+     * Sanitize input before saving (XSS protection)
+     *
+     * @param \Cake\Event\Event $event The event
+     * @param \Cake\Datasource\EntityInterface $entity The entity being saved
+     * @param \ArrayObject $options Save options
+     * @return bool
      */
     public function beforeSave(Event $event, $entity, $options)
     {
-        # Name sanitizen
+        // Sanitize name
         if (isset($entity->name) && !empty($entity->name)) {
             $entity->name = strip_tags($entity->name);
             $entity->name = html_entity_decode($entity->name, ENT_QUOTES | ENT_HTML5, 'UTF-8');
@@ -149,15 +154,15 @@ class SchoolsTable extends Table
             $entity->name = trim($entity->name);
         }
 
-        # Kurzname sanitizen (wichtig für Benutzernamen-Generierung)
+        // Sanitize short name (important for username generation)
         if (isset($entity->kurzname) && !empty($entity->kurzname)) {
             $entity->kurzname = strip_tags($entity->kurzname);
             $entity->kurzname = html_entity_decode($entity->kurzname, ENT_QUOTES | ENT_HTML5, 'UTF-8');
             $entity->kurzname = strip_tags($entity->kurzname);
             $entity->kurzname = trim($entity->kurzname);
-            # Zusätzlich: Nur alphanumerische Zeichen erlauben (keine Spaces, Sonderzeichen)
+            // Additional: Only allow alphanumeric characters (no spaces, special chars)
             $entity->kurzname = preg_replace('/[^a-z0-9äöüß]/i', '', $entity->kurzname);
-            # Kurzname zu lowercase konvertieren für Konsistenz
+            // Convert short name to lowercase for consistency
             $entity->kurzname = strtolower($entity->kurzname);
         }
 

--- a/src/Model/Table/TransactionsTable.php
+++ b/src/Model/Table/TransactionsTable.php
@@ -110,26 +110,31 @@ class TransactionsTable extends Table
     }
 
     /**
-     * Sanitize input vor dem Speichern (XSS-Schutz)
-     * Entfernt alle HTML/JavaScript-Tags aus Freitextfeldern
+     * Sanitize input before saving (XSS protection)
+     * Removes all HTML/JavaScript tags from free text fields
+     *
+     * @param \Cake\Event\Event $event The event
+     * @param \Cake\Datasource\EntityInterface $entity The entity being saved
+     * @param \ArrayObject $options Save options
+     * @return bool
      */
     public function beforeSave(Event $event, $entity, $options)
     {
-        # Liste der Felder die HTML-Tags enthalten könnten
+        // List of fields that could contain HTML tags
         $fieldsToSanitize = ['empfaenger_name', 'empfaenger_adresse', 'zahlungszweck'];
 
         foreach ($fieldsToSanitize as $field) {
             if (isset($entity->$field) && !empty($entity->$field)) {
-                # Entfernt alle HTML/JavaScript-Tags, behält nur Text
+                // Remove all HTML/JavaScript tags, keep only text
                 $entity->$field = strip_tags($entity->$field);
 
-                # Zusätzlich: Entities dekodieren (verhindert &lt;script&gt; Tricks)
+                // Additional: Decode entities (prevents &lt;script&gt; tricks)
                 $entity->$field = html_entity_decode($entity->$field, ENT_QUOTES | ENT_HTML5, 'UTF-8');
 
-                # Erneut strip_tags (falls durch entity_decode neue Tags entstanden)
+                // Strip tags again (in case entity_decode created new tags)
                 $entity->$field = strip_tags($entity->$field);
 
-                # Whitespace normalisieren
+                // Normalize whitespace
                 $entity->$field = trim($entity->$field);
             }
         }

--- a/src/Template/Schools/add.ctp
+++ b/src/Template/Schools/add.ctp
@@ -53,38 +53,38 @@
 
 <script>
 $(document).ready(function() {
-    # Kurzname automatisch aus Schulname generieren
+    // Auto-generate short name from school name
     function generateKurzname(name) {
         var kurzname = 'pts' + name.toLowerCase()
             .replace(/ä/g, 'ae')
             .replace(/ö/g, 'oe')
             .replace(/ü/g, 'ue')
             .replace(/ß/g, 'ss')
-            .replace(/[^a-z0-9]/g, ''); // Alle Sonderzeichen entfernen
+            .replace(/[^a-z0-9]/g, ''); // Remove all special characters
         return kurzname;
     }
 
-    # Bei Eingabe im Schulname-Feld
+    // On input in school name field
     $('#name').on('input', function() {
         var schoolName = $(this).val();
         var kurzname = generateKurzname(schoolName);
 
-        # Display-Feld aktualisieren
+        // Update display field
         $('#kurzname-display').val(kurzname);
-        # Hidden-Feld aktualisieren (wird submitted)
+        // Update hidden field (will be submitted)
         $('#kurzname').val(kurzname);
     });
 
-    # Vor dem Submit sicherstellen, dass Kurzname gesetzt ist
+    // Ensure short name is set before submit
     $('form#registerform').on('submit', function(e) {
         var schoolName = $('#name').val();
         if (schoolName && !$('#kurzname').val()) {
-            // Kurzname generieren falls noch nicht geschehen
+            // Generate short name if not done yet
             var kurzname = generateKurzname(schoolName);
             $('#kurzname').val(kurzname);
         }
 
-        // Prüfen ob Kurzname jetzt gesetzt ist
+        // Check if short name is now set
         if (!$('#kurzname').val() || $('#kurzname').val().length < 3) {
             e.preventDefault();
             alert('Bitte geben Sie einen Schulnamen ein (mindestens 3 Zeichen).');
@@ -92,7 +92,7 @@ $(document).ready(function() {
         }
     });
 
-    # Formular-Validierung
+    // Form validation
     $("form#registerform").validate({
         lang: 'de',
         rules: {

--- a/src/Template/Transactions/add.ctp
+++ b/src/Template/Transactions/add.ctp
@@ -117,8 +117,8 @@
                 input = parseFloat(input).toFixed(2);
                 input = input.replace('.', ','); // replace decimal point character with ,
                 input = input.replace(/(\d)(?=(\d{3})+(?!\d))/g, '$1.');
-                 // replace decimal point character with
-                //Zielzeichenkette zuweisen
+                // Replace decimal point character with thousand separator
+                // Assign target string
 
                 $this.val( function() {
                     return input;


### PR DESCRIPTION
## Summary
- Translate all PHPDoc headers and inline comments from German to English
- Keep user-facing strings (Flash messages, validation errors) in German
- Fix JavaScript comments using incorrect `#` syntax to use `//` (syntax error)
- Add missing PHPDoc blocks for undocumented methods
- Use fictional school name "PTS Sonnental" in code examples (instead of real school names)

## Files Changed
- `src/Controller/*.php` - All 5 controllers
- `src/Model/Table/SchoolsTable.php`
- `src/Model/Table/TransactionsTable.php`
- `src/Template/Schools/add.ctp` - JavaScript comments
- `src/Template/Transactions/add.ctp` - JavaScript comments

## Test plan
- [x] Run PHP syntax check: `php -l src/Controller/*.php src/Model/Table/*.php`
- [ ] Load site and verify functionality not broken
- [ ] Test school registration form (Schools/add.ctp)
- [ ] Test transaction form (Transactions/add.ctp)

Closes #2